### PR TITLE
🔒 Fix Unbounded File Read (DoS) in Skill Importers

### DIFF
--- a/generator/importers.py
+++ b/generator/importers.py
@@ -6,10 +6,17 @@ import yaml
 
 from .types import Skill, SkillPack
 
+MAX_IMPORT_FILE_SIZE = 1024 * 1024  # 1MB limit for safety
+
 
 class SkillImporter:
     def import_skills(self, source_path: Path) -> SkillPack:
         raise NotImplementedError
+
+    def _read_file_safely(self, file_path: Path) -> str:
+        """Read at most MAX_IMPORT_FILE_SIZE characters from a file."""
+        with open(file_path, "r", encoding="utf-8") as f:
+            return f.read(MAX_IMPORT_FILE_SIZE)
 
 
 class AgentRulesImporter(SkillImporter):
@@ -38,7 +45,7 @@ class AgentRulesImporter(SkillImporter):
         return SkillPack(name=pack_name, skills=skills)
 
     def _parse_file(self, file_path: Path) -> Optional[Skill]:
-        content = file_path.read_text(encoding="utf-8")
+        content = self._read_file_safely(file_path)
 
         # Extract frontmatter
         frontmatter_match = re.search(r"^---\n(.*?)\n---", content, re.DOTALL)
@@ -84,7 +91,7 @@ class VercelSkillsImporter(SkillImporter):
         return SkillPack(name=pack_name, skills=skills)
 
     def _parse_file(self, file_path: Path) -> Optional[Skill]:
-        content = file_path.read_text(encoding="utf-8")
+        content = self._read_file_safely(file_path)
 
         # Vercel skills usually have a simpler structure, often just markdown text.
         # But we need basic metadata. If they follow a specific frontmatter, good.

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -68,3 +68,40 @@ def test_vercel_skills_importer(vercel_skills_pack):
     assert skill.category == "vercel_skill"
     assert skill.source == "vercel-agent-skills"
     assert "You are an expert" in skill.usage_example
+
+
+def test_vercel_importer_truncates_large_file(tmp_path):
+    from generator.importers import MAX_IMPORT_FILE_SIZE, VercelSkillsImporter
+
+    skill_dir = tmp_path / "large-skill"
+    skill_dir.mkdir()
+    skill_file = skill_dir / "SKILL.md"
+
+    # Create content larger than the limit
+    content = "A" * (MAX_IMPORT_FILE_SIZE + 1000)
+    skill_file.write_text(content, encoding="utf-8")
+
+    importer = VercelSkillsImporter()
+    skill = importer._parse_file(skill_file)
+
+    assert skill is not None
+    assert len(skill.usage_example) == MAX_IMPORT_FILE_SIZE
+    assert skill.usage_example == content[:MAX_IMPORT_FILE_SIZE]
+
+
+def test_agent_rules_importer_handles_large_file(tmp_path):
+    from generator.importers import AgentRulesImporter, MAX_IMPORT_FILE_SIZE
+
+    rule_file = tmp_path / "large-rule.mdc"
+
+    # Frontmatter fits within the limit, but total file exceeds it
+    frontmatter = "---\ndescription: Large rule\nglobs: ['*']\n---\n"
+    junk = "B" * MAX_IMPORT_FILE_SIZE
+    rule_file.write_text(frontmatter + junk, encoding="utf-8")
+
+    importer = AgentRulesImporter()
+    skill = importer._parse_file(rule_file)
+
+    assert skill is not None
+    assert skill.description == "Large rule"
+    # Verify we can still parse frontmatter even if file is large


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Fixed an Unbounded File Read vulnerability in `generator/importers.py` where files were read entirely into memory using `Path.read_text()`.

### ⚠️ Risk: The potential impact if left unfixed
An attacker could provide an extremely large file (e.g., several GBs) which would cause the application to consume all available memory, leading to a Denial of Service (DoS) through a crash or system-wide slowdown (OOM).

### 🛡️ Solution: How the fix addresses the vulnerability
Introduced a `MAX_IMPORT_FILE_SIZE` constant (1MB) and a `_read_file_safely` helper method in the `SkillImporter` base class. This method uses `f.read(MAX_IMPORT_FILE_SIZE)` to ensure that only a safe amount of data is loaded into memory, even if the file on disk is much larger. Subclasses `AgentRulesImporter` and `VercelSkillsImporter` were updated to use this safe method. Added unit tests to verify that large files are correctly truncated and handled without crashing.

---
*PR created automatically by Jules for task [4307414848500460828](https://jules.google.com/task/4307414848500460828) started by @Amitro123*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import files larger than 1MB are now automatically limited during processing to ensure system stability.

* **Tests**
  * Added tests to verify proper truncation of large import files and continued correct parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->