### PR TITLE
fix: resolve 4 prg design/plan pipeline bugs (KNOWN-ISSUES)

### DIFF
--- a/docs/KNOWN-ISSUES.md
+++ b/docs/KNOWN-ISSUES.md
@@ -6,13 +6,13 @@ Discovered during session on 2026-03-30 by running `prg design` and `prg plan --
 
 ---
 
-### Issue 1 — `prg design`: Success Criteria section generates empty bullets
+### Issue 1 — `prg design`: Success Criteria section generates empty bullets ✅ FIXED
 
 **Command:** `prg design "Refactor remaining god-modules: rules_creator.py (864 LOC), agent.py (630 LOC)..."`
 
 **Expected:** Each success criterion has a concrete, measurable description.
 
-**Actual output:**
+**Actual output (before fix):**
 ```markdown
 ## Success Criteria
 
@@ -22,62 +22,70 @@ Discovered during session on 2026-03-30 by running `prg design` and `prg plan --
 - **Reliability**:
 ```
 
-Labels are correct but bodies are empty. The LLM prompt likely asks for criteria headings separately from their descriptions and one call returns nothing.
+**Root cause:** `_extract_bullets()` in `design_generator.py` used `re.finditer(r"^-\s+(.+)", text, re.MULTILINE)` — only captured the first line of each bullet. When the LLM writes multi-line criteria (label on one line, body indented below), only the label was captured.
 
-**Severity:** Medium — DESIGN.md is technically valid but not useful for planning.
+**Fix (PR `fix/known-issues-plan-design`):** Replaced the regex with a line-by-line parser that accumulates continuation lines until the next bullet or heading starts.
+
+**Severity:** Medium
 
 ---
 
-### Issue 2 — `prg plan --from-design`: Generates only 1 subtask instead of ~5
+### Issue 2 — `prg plan --from-design`: Generates only 1 subtask instead of ~5 ✅ FIXED
 
 **Command:** `prg plan --from-design DESIGN.md`
 
 **Expected:** Multiple concrete subtasks mapped to each architectural decision.
 
-**Actual:**
+**Actual (before fix):**
 ```
 Generated 1 subtasks
 Estimated time: 5 minutes
 ```
 
-For a design with 4 architecture decisions and 13 API contracts, this is severely under-decomposed.
+**Root cause:** `_parse_response()` in `task_decomposer.py` used a single regex `r"###?\s*(\d+)\.\s*"` to split LLM output. When the LLM used `##`, `**1.**`, or `1)` heading styles instead of `### 1.`, the regex didn't match → fallback single-task was returned.
 
-**Severity:** High — the core value of Feature 4 is task decomposition.
+**Fix:** Pre-normalise all common LLM heading variants (`## N.`, `**N.**`, `N)`) to `### N.` before splitting.
+
+**Severity:** High
 
 ---
 
-### Issue 3 — `prg plan`: Generated task references wrong file path
+### Issue 3 — `prg plan`: Generated task references wrong file path ✅ FIXED
 
-**Actual output:**
+**Actual output (before fix):**
 ```markdown
 **Files:**
 - `src/config.py` (new)
 ```
 
-This project uses `generator/` not `src/`. The planner hallucinated a generic Python project layout instead of grounding itself in the actual project tree.
+**Root cause:** `_build_design_prompt()` had no project tree injection. When `project_context=None` (CLI default), the LLM received no structural grounding and hallucinated a generic `src/` layout.
 
-**Severity:** High — hallucinated paths break agent handoffs downstream.
+**Fix:** Inject `build_project_tree(project_path)` output directly into `_build_design_prompt()`. `project_path` is now derived from `design_path.parent` in `from_design()`.
+
+**Severity:** High
 
 ---
 
-### Issue 4 — `prg plan`: Task content truncated mid-sentence
+### Issue 4 — `prg plan`: Task content truncated mid-sentence ✅ FIXED
 
-**Actual output:**
+**Actual output (before fix):**
 ```markdown
 - Define a Pydantic `BaseModel` named `LLMConfig` with fields: `provider: str`, `model: str`, `api_key:
 ```
 
-The task description is cut off. Likely a token-budget or string-slicing bug in the task serializer.
+**Root cause:** `_call_llm()` set `max_tokens=3000` — far too low when generating 5-8 detailed subtasks with Goals, Files, Changes, Tests, Dependencies, and Estimated fields each.
 
-**Severity:** High — incomplete tasks cannot be executed by `prg exec` or `prg next`.
+**Fix:** Increased `max_tokens` from `3000` → `5000`.
+
+**Severity:** High
 
 ---
 
 ## Summary Table
 
-| # | Feature | Severity | Area |
-|---|---------|----------|------|
-| 1 | `prg design` | Medium | LLM prompt / success criteria generation |
-| 2 | `prg plan` | High | Task decomposition (under-generates subtasks) |
-| 3 | `prg plan` | High | Hallucinated file paths (not grounded in project tree) |
-| 4 | `prg plan` | High | Task content truncated mid-sentence |
+| # | Feature | Severity | Status | Fix |
+|---|---------|----------|--------|-----|
+| 1 | `prg design` | Medium | ✅ Fixed | Multi-line `_extract_bullets()` in `design_generator.py` |
+| 2 | `prg plan` | High | ✅ Fixed | Normalise LLM heading variants in `_parse_response()` |
+| 3 | `prg plan` | High | ✅ Fixed | Inject project tree into `_build_design_prompt()` |
+| 4 | `prg plan` | High | ✅ Fixed | Raise `max_tokens` 3000 → 5000 in `_call_llm()` |

--- a/generator/design_generator.py
+++ b/generator/design_generator.py
@@ -134,8 +134,28 @@ class Design(BaseModel):
 
 
 def _extract_bullets(text: str) -> List[str]:
-    """Pull top-level bullet items from markdown text."""
-    return [m.group(1).strip() for m in re.finditer(r"^-\s+(.+)", text, re.MULTILINE)]
+    """Pull top-level bullet items from markdown text.
+
+    Each bullet may span multiple lines; continuation lines are indented or
+    start with optional whitespace but do NOT start with '- '.
+    """
+    items: List[str] = []
+    current: List[str] = []
+    for line in text.splitlines():
+        if re.match(r"^-\s+", line):
+            if current:
+                items.append(" ".join(current))
+            current = [line.lstrip("- ").strip()]
+        elif current and line.strip() and not re.match(r"^#+\s", line):
+            # continuation line of the current bullet
+            current.append(line.strip())
+        else:
+            if current:
+                items.append(" ".join(current))
+                current = []
+    if current:
+        items.append(" ".join(current))
+    return [item for item in items if item]
 
 
 class DesignGenerator:

--- a/generator/task_decomposer.py
+++ b/generator/task_decomposer.py
@@ -98,7 +98,8 @@ class TaskDecomposer(ArtifactGenerator):
         text = Path(design_path).read_text(encoding="utf-8")
         design = Design.from_markdown(text)
 
-        prompt = self._build_design_prompt(design, project_context)
+        project_path = Path(design_path).parent
+        prompt = self._build_design_prompt(design, project_context, project_path)
         raw = self._call_llm(prompt)
         tasks = self._parse_response(raw, design.title)
 
@@ -180,12 +181,18 @@ class TaskDecomposer(ArtifactGenerator):
 
         return tasks
 
-    def _build_design_prompt(self, design, project_context: Optional[Dict]) -> str:
+    def _build_design_prompt(self, design, project_context: Optional[Dict], project_path: Optional[Path] = None) -> str:
         """Build a prompt that decomposes an existing design into tasks."""
+        from generator.utils.readme_bridge import build_project_tree
+
         ctx_block = ""
+        if project_path and project_path.is_dir():
+            tree = build_project_tree(project_path, max_depth=3, max_items=60)
+            ctx_block = f"\n## Project Structure\n```\n{tree[:1200]}\n```\n"
+
         if project_context:
             meta = project_context.get("metadata", {})
-            ctx_block = (
+            ctx_block += (
                 f"\n## Project Context\n"
                 f"- Type: {meta.get('project_type', 'unknown')}\n"
                 f"- Tech: {', '.join(meta.get('tech_stack', []))}\n"
@@ -375,7 +382,7 @@ Generate the subtasks now:
             from generator.ai.factory import create_ai_client
 
             client = create_ai_client(self.provider, api_key=self.api_key)
-            return client.generate(prompt, max_tokens=3000) or ""
+            return client.generate(prompt, max_tokens=5000) or ""
         except Exception:
             return ""
 
@@ -397,8 +404,14 @@ Generate the subtasks now:
         tasks: List[SubTask] = []
         import re
 
+        # Normalise various LLM heading styles to "### N. " before splitting:
+        # "## 1.", "**1.**", "1)", bare "1." at line start, etc.
+        normalised = re.sub(r"(?m)^#+\s*(\d+)\.\s*", r"### \1. ", raw)
+        normalised = re.sub(r"(?m)^\*+(\d+)\.\*+\s*", r"### \1. ", normalised)
+        normalised = re.sub(r"(?m)^(\d+)\)\s+", r"### \1. ", normalised)
+
         # Split on numbered headings like "### 1. Title" or "1. Title"
-        blocks = re.split(r"###?\s*(\d+)\.\s*", raw)
+        blocks = re.split(r"###?\s*(\d+)\.\s*", normalised)
         # blocks[0] is preamble, then alternating (number, content)
         i = 1
         while i < len(blocks) - 1:


### PR DESCRIPTION
Issue 1 (design): _extract_bullets() now handles multi-line bullet content; previously only captured the label line, leaving criteria bodies empty.

Issue 2 (plan): _parse_response() normalises LLM heading variants (##, **N.**, N)) to ### N. before splitting, preventing the single-fallback-task regression.

Issue 3 (plan): _build_design_prompt() injects build_project_tree() output so the LLM is grounded in the real project layout instead of hallucinating src/.

Issue 4 (plan): _call_llm() max_tokens raised 3000 → 5000 to prevent mid-sentence truncation when generating 5-8 detailed subtasks.

All 42 targeted tests pass; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incomplete extraction of multi-line bullet content in design specifications
  * Enhanced project structure context integration for improved accuracy
  * Improved robustness of heading format recognition in task decomposition across multiple heading styles
  * Increased generation capacity to support more complete output

* **Documentation**
  * Documented resolution of four previously identified issues with detailed before/after analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->